### PR TITLE
removed open action trigger after sequence in toggle mode

### DIFF
--- a/app/stratagems.py
+++ b/app/stratagems.py
@@ -66,7 +66,7 @@ class Stratagems:
     def toggle_menu(self):
         if self.config["settings"]["open_mode"] == "hold":
             (Key.up if self.menu_open else Key.down)(self.bindings["O"])
-        else:
+        elif not self.menu_open:
             Key.press(self.bindings["O"])
         self.menu_open = not self.menu_open
 


### PR DESCRIPTION
## Description

Hotfix for toggle menu mode.
Removed toggle menu action trigger after the sequence, as the game hides the stratagem menu upon stratagem activation.

keeping the event trigger would result in stratagem activation while menu still open