### PR TITLE
Added new option "press_time" to set the length of time a key is pressed down for.

### DIFF
--- a/app/constants/config.py
+++ b/app/constants/config.py
@@ -10,7 +10,7 @@ default_settings: AppConfig = {
         "down": "80.1",
         "open": "29",
     },
-    "settings": {"open_mode": "hold", "delay_min": "20", "delay_max": "50"},
+    "settings": {"open_mode": "hold", "delay_min": "20", "delay_max": "50", "press_time": "20"},
 }
 
 settings_description = {
@@ -20,13 +20,15 @@ settings_description = {
     "right": "Right",
     "open": "Open stratagem menu",
     "open_mode": "Open mode (Hold/Toggle/None)",
-    "delay_min": "Minimum delay",
-    "delay_max": "Maximum delay",
+    "delay_min": "Minimum delay between key presses (ms)",
+    "delay_max": "Maximum delay between key presses (ms)",
+    "press_time": "Time to hold a key down for (ms)",
 }
 
 settings_prompts = {
     "open_mode": "Do you want to use HOLD, TOGGLE or NONE mode for the stratagem open key? (h/t/n)",
-    "delay_min": "Enter the minimum delay (ms)",
-    "delay_max": "Enter the maximum delay (ms)",
+    "delay_min": "Enter the minimum delay between key presses (ms)",
+    "delay_max": "Enter the maximum delay between key presses (ms)",
+    "press_time": "Enter the time to hold a key down for (ms)",
     "open_mode_retry": "Invalid input. Please enter 'h' for HOLD or 't' for TOGGLE"
 }

--- a/app/stratagems.py
+++ b/app/stratagems.py
@@ -65,7 +65,7 @@ class Stratagems:
                 * 0.001,
                 4,
             )
-            Key.press(self.bindings[element])
+            Key.press(self.bindings[element], float(self.config["settings"]["press_time"]) * 0.001)
             log(f"sleeping for {delay}s")
             time.sleep(delay)
 
@@ -75,7 +75,7 @@ class Stratagems:
         if self.config["settings"]["open_mode"] == "hold":
             (Key.up if self.menu_open else Key.down)(self.bindings["O"])
         elif not self.menu_open:
-            Key.press(self.bindings["O"])
+            Key.press(self.bindings["O"], float(self.config["settings"]["press_time"]) * 0.001)
         self.menu_open = not self.menu_open
         time.sleep(0.02)
 

--- a/app/types/config.py
+++ b/app/types/config.py
@@ -1,7 +1,7 @@
 from typing import Literal, TypedDict
 
 AvailableKeys = Literal["up", "down", "left", "right", "open"]
-AvailableSettings = Literal["open_mode", "delay_min", "delay_max"]
+AvailableSettings = Literal["open_mode", "delay_min", "delay_max", "press_time"]
 AvailableOpenModes = Literal["hold", "toggle", "none"]
 OpenModeMap = {
     "h": "hold",
@@ -22,6 +22,7 @@ class Settings(TypedDict):
     open_mode: AvailableOpenModes
     delay_min: str
     delay_max: str
+    press_time: str
 
 
 class AppConfig(TypedDict):


### PR DESCRIPTION
I had an issue where the default length of time a key was pressed down for (0.02) was too short to be acknowledged.

This pull request added a new option "press_time", which allows this time to be customised.

Thanks
Gavin