### PR TITLE
increased default press_time to 40, added unpacked version to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ lint-all:
 build:
 	.venv\Scripts\activate && \
 	pyinstaller app.py --onefile --noconsole --icon=icons/helldivers.ico --name stratagems
+	pyinstaller app.py --onedir --noconsole --icon=icons/helldivers.ico --name stratagems_unpacked
 	pyinstaller settings.py --onefile --icon=icons/settings.ico --name settings
 	pwsh -Command "Copy-Item -Path './config/codes.json' -Destination './dist/'"
 

--- a/app/constants/config.py
+++ b/app/constants/config.py
@@ -10,7 +10,7 @@ default_settings: AppConfig = {
         "down": "80.1",
         "open": "29",
     },
-    "settings": {"open_mode": "hold", "delay_min": "20", "delay_max": "50", "press_time": "20"},
+    "settings": {"open_mode": "hold", "delay_min": "20", "delay_max": "50", "press_time": "40"},
 }
 
 settings_description = {


### PR DESCRIPTION
## Description

This increases the default press_time value to 40 and adds an additional entry to the makefile so that both the packed and unpacked versions are compiled